### PR TITLE
feat: Add pitch scaled audio notifications for tiny transfers and updated other pitches

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,8 +118,8 @@ export default function Home() {
   const [hideZeroSTT, setHideZeroSTT] = useState(true)
   const [showFiltersDropdown, setShowFiltersDropdown] = useState(false)
   const filtersDropdownRef = useRef<HTMLDivElement>(null)
-  const { toggleMute, playTransferSound } = useNotifications()
-  const { transactions, stats, isConnected, error, network: networkInfo } = useBlockchain(network, isListening, playTransferSound)
+  const { toggleMute, playTransferSound, playCustomSound } = useNotifications()
+  const { transactions, stats, isConnected, error, network: networkInfo } = useBlockchain(network, isListening, playTransferSound, playCustomSound)
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/lib/blockchain-hooks.ts
+++ b/lib/blockchain-hooks.ts
@@ -48,7 +48,8 @@ export interface NetworkStats {
 export function useBlockchain(
   network: NetworkType, 
   isListening: boolean,
-  playTransferSound: (amount: number) => void
+  playTransferSound: (amount: number) => void,
+  playCustomSound: (frequency: number, duration: number, volume: number, waveType: OscillatorType) => void
 ) {
   const [provider, setProvider] = useState<ethers.JsonRpcProvider | null>(null)
   const [transactions, setTransactions] = useState<Transaction[]>([])
@@ -148,7 +149,7 @@ export function useBlockchain(
                   newTxs.push(txData)
                   
                   // Store transfer amounts for pitch-based sound
-                  if (txType === 'transfer' && parseFloat(txData.value) > 0) {
+                  if (txType === 'transfer' && parseFloat(txData.value) >= 0) {
                     transfersForSound.push(parseFloat(txData.value))
                   }
                 }
@@ -162,7 +163,13 @@ export function useBlockchain(
         // Play pitch-scaled sounds for each qualifying transfer
         transfersForSound.forEach((amount, index) => {
           setTimeout(() => {
-            playTransferSound(amount)
+            if (amount > 0 && amount < 0.0005) {
+              // Extremely quiet, barely audible sound for tiny transfers
+              playCustomSound(200, 0.1, 0.04, 'sine') // Very low frequency, very short, very quiet
+            } else {
+              // Normal pitch-scaled sound for regular transfers
+              playTransferSound(amount)
+            }
           }, index * 600) // Stagger sounds by 600ms
         })
 

--- a/lib/use-notifications.ts
+++ b/lib/use-notifications.ts
@@ -100,8 +100,8 @@ export function useNotifications() {
     // Calculate frequency based on transfer amount
     // Use logarithmic scale for better perception across wide value ranges
     // Lower amounts (closer to 1 STT) = lower pitch, higher amounts = higher pitch
-    const minFreq = 400  // Low note for small amounts
-    const maxFreq = 1200 // High note for large amounts
+    const minFreq = 500  // Low note for small amounts
+    const maxFreq = 1400 // High note for large amounts
     
     // Log scale: log(amount) maps to frequency range
     // Clamp amount between 0.1 and 1000 for reasonable frequency range
@@ -114,7 +114,14 @@ export function useNotifications() {
     const normalizedValue = (logAmount - logMin) / (logMax - logMin)
     const frequency = minFreq + (normalizedValue * (maxFreq - minFreq))
     
-    playSound({ frequency, duration: 0.5, volume: 0.3, waveType: 'sine' })
+    // Play a distinctive two-tone alert sound
+    // First tone - main pitch
+    playSound({ frequency, duration: 0.2, volume: 0.35, waveType: 'triangle' })
+    
+    // Second tone - harmonic (slightly higher) for alert effect
+    setTimeout(() => {
+      playSound({ frequency: frequency * 1.25, duration: 0.3, volume: 0.3, waveType: 'triangle' })
+    }, 150)
   }, [playSound])
 
   const mute = useCallback(() => {


### PR DESCRIPTION
# Overview
- **Transfers over and equal to 0.0005 STT)**: 
  - Distinctive two-tone triangle wave alert
  - Pitch-scaled from 500Hz to 1400Hz based on transfer amount (logarithmic scale)
  - Louder and more attention-grabbing (0.35 volume)
  - Creates a "ding-ding" notification effect

- **Tiny Transfers (<0.0005 STT)**: 
  - Subtle low-frequency sine wave (200Hz)
  - Very quiet (0.04 volume) and short (0.1s duration)
  - Provides ambient awareness without being intrusive

## Showing all the transactions
https://github.com/user-attachments/assets/c3cf9993-5623-40ec-8932-14a509f3a772

## With the filter of Min 0.0005 STT Transfers
https://github.com/user-attachments/assets/23a94a82-d406-49a5-80e9-ceadc3fa72d4