### PR TITLE
feat: sync audio notifications with UI filter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,7 +119,7 @@ export default function Home() {
   const [showFiltersDropdown, setShowFiltersDropdown] = useState(false)
   const filtersDropdownRef = useRef<HTMLDivElement>(null)
   const { toggleMute, playTransferSound, playCustomSound } = useNotifications()
-  const { transactions, stats, isConnected, error, network: networkInfo } = useBlockchain(network, isListening, playTransferSound, playCustomSound)
+  const { transactions, stats, isConnected, error, network: networkInfo } = useBlockchain(network, isListening, playTransferSound, playCustomSound, showOnlySTTTransfers, hideZeroSTT)
 
   // Close dropdown when clicking outside
   useEffect(() => {


### PR DESCRIPTION
# Overview
- Audio now respects "Show only STT Transfers" and "Hide STT under 0.0005" filters
- When both filters are active: only meaningful transfer alerts play (≥0.0005 STT), tiny transfers muted
- When filters are off: both tiny transfer sounds and meaningful alerts play
- Pass filter state from page component to blockchain hook for reactive audio control

Closes #20

https://github.com/user-attachments/assets/1c14ec40-1e72-4cc9-a320-45f32a1ce1b0

