### PR TITLE
feat: add treble clef to music staff background

### DIFF
--- a/components/MusicStaffBackground.tsx
+++ b/components/MusicStaffBackground.tsx
@@ -68,6 +68,21 @@ export const MusicStaffBackground = forwardRef<MusicStaffBackgroundRef>((props, 
               marginTop: groupIndex === 0 ? '80px' : '60px',
             }}
           >
+            {/* Treble Clef */}
+            <div 
+              className="absolute left-4 z-10"
+              style={{
+                top: '-18px',
+                fontSize: '96px',
+                color: '#8b7355',
+                opacity: 0.4,
+                lineHeight: 1,
+                fontFamily: 'serif',
+              }}
+            >
+              𝄞
+            </div>
+
             {/* Five staff lines per group */}
             {[...Array(5)].map((_, lineIndex) => (
               <div


### PR DESCRIPTION
# Overview
- Adds a treble clef (𝄞) to the left side of each music staff group to make it immediately clear that the background represents musical notation.
- Positioned clef on the left side of each staff group
- Styled with correct sizing and matching color 

## Screenshot
<img width="1913" height="845" alt="Screenshot 2025-11-14 at 11 29 29 PM" src="https://github.com/user-attachments/assets/0dd78af0-a0bb-44cf-ab5a-70f6295f34f0" />

## Fixes
- This fixes Issue #31 
